### PR TITLE
allow theme-loader.php to work with child themes

### DIFF
--- a/theme-loader.php
+++ b/theme-loader.php
@@ -14,8 +14,8 @@ if ( defined( 'TRUONGWP_GALLERY_META_BOX_PATH' ) ) {
 /*
  * Change these value if need.
  */
-define( 'TRUONGWP_GALLERY_META_BOX_PATH', get_template_directory() . '/gallery-meta-box/' );
-define( 'TRUONGWP_GALLERY_META_BOX_URL', get_template_directory_uri() . '/gallery-meta-box/' );
+define( 'TRUONGWP_GALLERY_META_BOX_PATH', get_stylesheet_directory() . '/gallery-meta-box/' );
+define( 'TRUONGWP_GALLERY_META_BOX_URL', get_stylesheet_directory_uri() . '/gallery-meta-box/' );
 
 require_once TRUONGWP_GALLERY_META_BOX_PATH . 'class-truongwp-gallery-meta-box.php';
 


### PR DESCRIPTION
As is the code doesn't work when used in child themes. The two WP function call changes allow this.